### PR TITLE
dereference paths inside maps

### DIFF
--- a/evaluate.ts
+++ b/evaluate.ts
@@ -28,12 +28,25 @@ export function createYSEnv(parent = global): PSEnv {
       let env = createYSEnv(scope);
 
       if (value.type === "ref") {
-        let [key] = value.path;
+        let { key, path, spec } = value;
+
         let result = scope.value[key];
         if (!result) {
-          throw new ReferenceError(`'${value.name}' not defined`);
+          throw new ReferenceError(`'${value.key}' not defined`);
         } else {
-          return result;
+          return path.reduce((current, segment) => {
+            if (current.type === 'map') {
+              let next = current.value[segment];
+              if (!next) {
+                throw new ReferenceError(`no such key '${segment}' in ${spec}`);
+              } else {
+                return next;
+              }
+            } else {
+              throw new TypeError(`cannot de-reference key ${segment} from ${current.type}`);
+            }
+          }, result);
+
         }
       } else if (value.type === "map") {
         let map = value.value;

--- a/load.ts
+++ b/load.ts
@@ -51,13 +51,13 @@ export function* load(
           `imported names must be references, but found ${name.type}`,
         );
       }
-      let value = dep.symbols.value[name.name];
+      let value = dep.symbols.value[name.key];
       if (!value) {
         throw new Error(
-          `${source.value} does not define a value named '${name.name}'`,
+          `${source.value} does not define a value named '${name.key}'`,
         );
       }
-      symbols.value[name.name] = value;
+      symbols.value[name.key] = value;
     }
   }
 

--- a/test/modules/module.yaml.ts
+++ b/test/modules/module.yaml.ts
@@ -33,7 +33,7 @@ function ys2string(value: PSValue): PSString {
     case "ref":
       return {
         type: "string",
-        value: `^${value.name}`,
+        value: `^${value.key}`,
       };
     case "fn":
       return {

--- a/test/ref.test.ts
+++ b/test/ref.test.ts
@@ -1,0 +1,20 @@
+import { describe, eval2js, expect, it } from "./suite.ts";
+
+describe("a reference", () => {
+  it("evaluates a simple value", async () => {
+    expect(await eval2js(`five`, { five: 5 })).toEqual(5);
+  });
+  it("evaluates a value nested in a map", async () => {
+    expect(
+      await eval2js("numbers.ints.five", { numbers: { ints: { five: 5 } } }),
+    ).toEqual(5);
+  });
+  it("fails to evaluate if the value does not exist", async() => {
+    try {
+      await eval2js("empty.nothing", { empty: {} });
+      throw new Error('expected dereference to fail, but it did not');
+    } catch (error) {
+      expect(error.message).toMatch(/no such key/);
+    }
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -41,8 +41,9 @@ export interface PSString {
 
 export interface PSRef {
   type: "ref";
-  name: string;
-  path: [string, ...string[]];
+  spec: string;
+  key: string;
+  path: string[];
 }
 
 export interface PSList {


### PR DESCRIPTION
## Motivation
Right now, you can only reference singe value with refernences, but for non-scalar values such as lists and maps, there is no way to actually reference values _within_ those values. So this:

```yaml
let:
  x:
    "y":
      "z": "Hello There"
do x.y.z
```

Will actually evaluate to the map contained at `x`. in other words, the path is completely ignored.

## Approach
This allows references to have a "path" which is `.` separated which will then be used to produce a value. So the above example now produces "Hello There"