### PR TITLE
Ensure function bodies are lexically bound

### DIFF
--- a/data.ts
+++ b/data.ts
@@ -2,6 +2,7 @@ import type {
   PSBoolean,
   PSExternal,
   PSFn,
+  PSFnCall,
   PSList,
   PSMap,
   PSNumber,
@@ -9,6 +10,7 @@ import type {
   PSString,
   PSValue,
 } from "./types.ts";
+import type { Operation } from "./deps.ts";
 
 export function number(value: number): PSNumber {
   return { type: "number", value };
@@ -53,6 +55,16 @@ export function external(
   return { type: "external", value, view };
 }
 
-export function fn(value: PSFn["value"]): PSFn {
-  return { type: "fn", value };
+export function fn(
+  call: (cxt: PSFnCall) => Operation<PSValue>,
+  param: PSFn["param"],
+): PSFn {
+  return {
+    type: "fn",
+    param,
+    value: {
+      type: "native",
+      call,
+    },
+  };
 }

--- a/test/fn.test.ts
+++ b/test/fn.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, expect, it } from "./suite.ts";
 import * as ps from "../mod.ts";
+import { lookup } from "../psmap.ts";
 
 describe("fn", () => {
   it("can be called directly", async () => {
@@ -10,5 +11,45 @@ describe("fn", () => {
     expect(
       (await interp.call(fn, ps.string("World"))).value,
     ).toEqual("Hello World!");
+  });
+
+  it("can access the local symbols of a function in which it was defined", async () => {
+    let program = ps.parse("$(x): { $(y): '%($x) %($y)' }");
+    let interp = ps.createPlatformScript();
+    let fn = await interp.eval(program);
+
+    assert(fn.type === "fn");
+    let inner = await interp.call(fn, ps.string("Hello"));
+    assert(inner.type === "fn");
+    let result = await interp.call(inner, ps.string("World"));
+    expect(result.value).toEqual("Hello World");
+  });
+
+  it("can access the module scope in which it was defined", async () => {
+    let program = ps.parse(`
+saying: "Hello World"
+say: { $(): $saying }
+`);
+
+    let interp = ps.createPlatformScript();
+    let mod = await interp.moduleEval(program, import.meta.url);
+    let say = lookup("say", mod.symbols);
+    assert(say.type === "just");
+    assert(say.value.type === "fn");
+    expect((await interp.call(say.value, ps.boolean(false))).value).toEqual(
+      "Hello World",
+    );
+  });
+
+  it("can acesss imported symbols of the module in which it was defined", async () => {
+    let program = ps.parse(`
+$import:
+  names: [say]
+  from: modules/fn-scope.yaml
+$do: { $say: Hello }
+`);
+
+    let interp = ps.createPlatformScript();
+    await interp.moduleEval(program, import.meta.url);
   });
 });

--- a/test/modules/fn-scope.yaml
+++ b/test/modules/fn-scope.yaml
@@ -1,0 +1,6 @@
+$import:
+  names: [str]
+  from: ./nodeps.yaml
+
+to: $str
+say: { $(thing): "%($thing) %($to): %($str)" }

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -1,0 +1,37 @@
+// import type { PSValue, PSRef } from "../types.ts";
+
+// import { assert, describe, expect, it } from "./suite.ts";
+// import * as ps from "../mod.ts";
+
+// describe("scope", () => {
+//   it("can tell if all of the references are balanced", () => {
+//     let program = ps.parse("$(x): { $(y): '%($x) %($y)' }");
+//     assert(program.type === "fn");
+//     let holes = unsatisfied(program);
+//     expect(holes.length).toEqual(0);
+//   });
+
+//   it("can tell if all of the references are satisfied", () => {
+//     let program = ps.parse("$(x): { $(): '%($x) %($y)' }");
+//     assert(program.type === "fn");
+//     let holes = unsatisfied(program);
+//     let [hole] = holes;
+//     expect(hole).toBeDefined();
+//     expect(hole.key).toEqual('y');
+//   });
+// })
+
+// function unsatisfied(value: PSValue): PSRef[] {
+//   if (value.type === 'fn') {
+//     let { body, param } = value;
+//     return unsatisfied(body).filter(ref => ref.key !== param.name)
+//   } else if (value.type === 'template') {
+//     return value.expressions.reduce((refs, expr) => {
+//       return refs.concat(unsatisfied(expr.expression));
+//     },[] as PSRef[]);
+//   } else if (value.type === 'ref') {
+//     return [value];
+//   } else {
+//     return [];
+//   }
+// }

--- a/types.ts
+++ b/types.ts
@@ -22,6 +22,7 @@ export type PSValue =
   | PSList
   | PSMap
   | PSFn
+  | PSFnCall
   | PSExternal;
 
 export type PSMapKey =
@@ -34,7 +35,6 @@ export type PSMapEntry = [PSMapKey, PSValue];
 
 export type PSLiteral<T extends PSValue = PSValue> = T & {
   node: YAMLNode;
-  parent?: YAMLNode;
 };
 
 export interface PSNumber {
@@ -83,11 +83,24 @@ export interface PSExternal {
 
 export interface PSFn {
   type: "fn";
-  value(call: PSFnCall): Operation<PSValue>;
+  param: { name: string };
+  value: {
+    type: "native";
+    call(cxt: PSFnCall): Operation<PSValue>;
+  } | {
+    type: "platformscript";
+    body: PSValue;
+  };
 }
 
 export interface PSFnCall {
+  type: "fncall";
+  value: PSFn;
   arg: PSValue;
   rest: PSMap;
   env: PSEnv;
+}
+
+export interface PSFnParam {
+  name: string;
 }


### PR DESCRIPTION
## Motivation

Houston, we had a problem! functions bodies were not lexically bound😬

That means the following code did not work as expected:

```
$let
  x: world
  say: { $(): "%(hello) %($x)" }
$do:
  {$say: true }
```

Instead of printing "hello world" as expected, it failed with a ReferenceError of `x` is not defined.

## Approach

We fix this by using a two-phase computation. Before, we had a single phase of evaluation (`eval`) to convert a value into a result value:

```
value -eval()-> result
```

Now, we have two phases, `bind` and `eval`

```
value -bind()-> bound -eval()-> result
```

Currently binding a scope to a value, means performing all reference lookups ahead of time and making sure that we have all requisite values that we will need for evaluation. So, for example in our template, its ealuation looks like this:

```
"%(hello) %($x)" -bind()-> "%(hello) %(world)" --eval()--> "hello world"
```

for function invocations, which are represented as maps whose first key is a `ref`, we dereference the function eagerly and convert the `map` into a `fncall` value which is a first-class PlatformScript value now. This can ensure that just like we substitute a reference value, we can also always make sure that any functions that were in scope when a block of code is evaluated, will remain in scope. Let's take the following code as an example:

```yaml
$let:
  salutation: hello
  greet: { $(to): "%($salutation) %($to)" }
  say: { $(): { $greet: world } }
```

in the binding, the map `$greet: world` is converted from a `map` value into a `fncall` and the function referenced by `greet` is captured from the scope at that point, so when we eval, we have already looked up the function and know it is there. In the phased computation:

```
map($greet: world) -bind()-> fncall(greet,"world") -eval()-> string("hello world")
```
This multi-phase expansion lays the groundwork for a macro system which we will surely have.

Function parameters
-------------------

There are some breaking changes related to the way functions are constructed. Specifically, functions _prevent_ their parameters from being bound during the `bind()` operation. This must be, because in the function `$(x): hello %($x)` we will not know the value of `x` until we actually call the function, so binding it too soon would be a big, fat error.

However, this means that we now need to track the _name_ of a function parameter in a function so that we can be sure to exclude it from the values being dereferenced during `bind()`. While this is not strictly necessary for `native` functions, I went ahead and made naming the parameter mandatory there because it will help with `intellisense` on native functions, and also because we will need native functions to provide type information about their inputs and outputs as well.